### PR TITLE
fix: Restore goodmorning matcher by running matchers before state update

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -108,8 +108,8 @@ func ProvideTelegramWebhookHandler() telegramclient.WebhookHandlerInterface {
 	return telegramclient.NewHandler(
 		&ProvideConfig().Telegram,
 		func(messageIn telegramclient.WebhookMessageStruct) {
-			stateService.ProcessMessage(messageIn)
 			matchersRegistry.Process(messageIn)
+			stateService.ProcessMessage(messageIn)
 		},
 	)
 }

--- a/interfaces/config.go
+++ b/interfaces/config.go
@@ -24,7 +24,7 @@ type DatabaseConfigStruct struct {
 		Port     uint
 		DBName   string
 		User     string
-		Password string
+		Password string //nolint:gosec // G117: false positive, this is a config struct field, not a hardcoded secret
 		SSL      string
 		Timezone string
 	}

--- a/pkg/matchers/atall/atall.go
+++ b/pkg/matchers/atall/atall.go
@@ -51,11 +51,9 @@ func makeReplies(text string, users []interfaces.StatsUserStruct) ([]telegramcli
 
 	var textSb52 strings.Builder
 	for _, user := range users {
-		textSb52.WriteString(fmt.Sprintf(
-			" [%s](tg://user?id=%d)",
+		fmt.Fprintf(&textSb52, " [%s](tg://user?id=%d)",
 			telegramclient.EscapeMarkdown(user.Username),
-			user.ID,
-		))
+			user.ID)
 	}
 
 	text += textSb52.String()


### PR DESCRIPTION
## Summary

- stateService.ProcessMessage() was called before matchersRegistry.Process(), which caused it to immediately overwrite lastPost[userID] with time.Now()
- The goodmorning matcher's doesMatch() would then read back the current message's own timestamp via GetLastPost(), making now.Sub(*lastPost) essentially zero — never satisfying the 6-hour threshold
- Result: the goodmorning matcher silently never fired

The fix swaps the order so matchers run first (reading the previous last-post time) and state is updated afterwards.

## Note

A first-time user whose very first message is `/roll stats @themselves` will get a user-not-found response, since their stats row does not exist until ProcessMessage runs. This edge case was the original reason for the order swap and is considered an acceptable limitation.

## Test plan

- [ ] Send a message in the morning (06:00-14:00) after a gap of 6+ hours and confirm a goodmorning reply is posted
- [ ] Send a follow-up message within 6 hours and confirm no second goodmorning reply
- [ ] Verify /roll and /roll stats continue to work normally

Generated with [Claude Code](https://claude.com/claude-code)